### PR TITLE
--show-body flag placement no longer affects subsequent flags/entries

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 
+const optionDefinitions = {
+  boolean: ['show-body'],
+};
+
 const minimist = require('minimist');
-const argv = minimist(process.argv.slice(2));
+const argv = minimist(process.argv.slice(2), optionDefinitions);
 const opts = require('./opts')(argv);
 
 const pack = require('../package.json');

--- a/test/bin/index.js
+++ b/test/bin/index.js
@@ -71,7 +71,7 @@ test('bin/index: showBody', (_, fail) => {
   server.listen(0);
   server.on('listening', () => {
     const port = server.address().port;
-    exec(`node ${process.cwd()}/bin/index.js http://localhost:${port} --show-body`, mustCall((err, result) => {
+    exec(`node ${process.cwd()}/bin/index.js --show-body http://localhost:${port}`, mustCall((err, result) => {
       if (err) fail(err);
       assert(result.match(/DNS Lookup/));
       assert(result.match(/TCP Connection/));


### PR DESCRIPTION
Currently the `--show-body` flag needs to be used at the end of the command. This change tells minimist that the flag is boolean which prevents minimist from using the next flag/entry as a value for the flag.