### PR TITLE
Pass object literal to main instead of parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ $ npm install httpstat -g
 # Usage as tool
 
 ```
-$ httpstat http://example.com/
-$ httpstat -X POST -d test http://example.com/
+$ httpstat http://httpbin.org/get
+$ httpstat -X POST -d test http://httpbin.org/post
 ```
 
 # Install as library
@@ -32,7 +32,7 @@ $ npm install httpstat -S
 ```javascript
 const httpstat = require('httpstat');
 
-httpstat('http://example.com', /* option, headers, body */).then((result) => {
+httpstat('http://httpbin.org/post', { method: 'POST' }).then((result) => {
   console.log(result); // time property has duration time.
 }).catch((e) => {
   console.error(e);
@@ -41,10 +41,13 @@ httpstat('http://example.com', /* option, headers, body */).then((result) => {
 
 # API
 
-## httpstat(url, [options], [headers], [body]) - return Promise
+## httpstat(url, [options]) - return Promise
 
-- url, type: string, `url` is a request target url. required.
-- options, type: object, `options` is a http(s) request options see [node http API](https://nodejs.org/docs/latest/api/http.html#http_http_request_options_callback)
-- headers, type: array, headers is http request headers like ["Content-Type: application/json"]
-- body, type: string, body is http request body
+- `url` (type: `string`, required): Request target url
+- `options` (type: `object`, optional)
+  - `method`: (type: `string`, default: `GET`): HTTP request method
+  - `insecure`: (type: `boolean`): Allow connections to SSL sites without certs
+  - `headers`: (type: `array` of `string`): Request headers
+  - `data`: (type: `string`): Request body,
+  - `formData`: (type: `array` of `string`):  HTTP multipart POST data
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -36,6 +36,11 @@ if (opts.help) {
   showHelp();
 }
 
-main(opts.target, opts.options, opts.headers, opts.data, opts.formInputs).then(
-  (results) => reporter(results, opts)
-).catch(console.error);
+main(opts.target, {
+  method: opts.method,
+  insecure: opts.insecure,
+  headers: opts.headers,
+  data: opts.data,
+  formData: opts.formData,
+}).then(results => reporter(results, opts))
+.catch(console.error);

--- a/bin/opts.js
+++ b/bin/opts.js
@@ -17,19 +17,17 @@ const opts = (argv) => {
   const target = argv._[0];
 
   const headers = argToArray(header);
-  const formInputs = argToArray(form);
+  const formData = argToArray(form);
 
   return {
-    options: {
-      method: method,
-      rejectUnauthorized: !insecure,
-    },
+    method,
+    insecure,
     help: help,
     version: version,
     showBody: showBody,
     target: target,
     data: data,
-    formInputs: formInputs,
+    formData: formData,
     headers: headers
   };
 };

--- a/index.js
+++ b/index.js
@@ -5,8 +5,13 @@ const https = require('https');
 const parse = require('url').parse;
 const writeFormData = require('./lib/formDataWriter');
 
-module.exports = function main(arg, opts, headers, data, formInputs) {
-  const url = Object.assign(parse(arg), opts);
+module.exports = function main(target, options) {
+  options = options || {};
+  const httpOptions = {
+    method: options.method,
+    rejectUnauthorized: !options.insecure,
+  };
+  const url = Object.assign(parse(target), httpOptions);
   return new Promise((resolve, reject) => {
     const protocol = url.protocol === 'https:' ? https : http;
     var begin = Date.now();
@@ -54,8 +59,8 @@ module.exports = function main(arg, opts, headers, data, formInputs) {
 
     req.on('error', reject);
 
-    if (headers) {
-      headers.forEach((header) => {
+    if (options.headers) {
+      options.headers.forEach((header) => {
         const entries = header.split(':');
         const name = entries[0].trim();
         const value = entries[1].trim();
@@ -63,12 +68,12 @@ module.exports = function main(arg, opts, headers, data, formInputs) {
       });
     }
 
-    if(formInputs) {
-      writeFormData(req, formInputs);
+    if(options.formData) {
+      writeFormData(req, options.formData);
     }
 
-    if (data) {
-      req.write(data);
+    if (options.data) {
+      req.write(options.data);
     }
 
     req.end();

--- a/test/index.js
+++ b/test/index.js
@@ -46,7 +46,9 @@ test('index.js: request to https server', () => {
   server.on('listening', () => {
     const port = server.address().port;
     const requestUrl = `https://localhost:${port}/`;
-    httpstat(requestUrl, { rejectUnauthorized: false }).then(mustCall((results) => {
+    httpstat(requestUrl, {
+      insecure: true,
+    }).then(mustCall((results) => {
       const time = results.time;
       const res = results.response;
       const url = results.url;
@@ -73,11 +75,10 @@ test('index.js: request with headers to http server', () => {
   server.on('listening', () => {
     const port = server.address().port;
     const requestUrl = `http://localhost:${port}/`;
-    httpstat(
-      requestUrl, 
-      { method: 'POST' }, 
-      ["Content-Type: application/json"]
-    ).then((results) => {
+    httpstat(requestUrl, {
+      method: 'POST',
+      headers: ['Content-Type: application/json'],
+    }).then((results) => {
       server.close();
     });
   });
@@ -96,12 +97,11 @@ test('index.js: request with headers with body to http server', () => {
   server.on('listening', () => {
     const port = server.address().port;
     const requestUrl = `http://localhost:${port}/`;
-    httpstat(
-      requestUrl, 
-      { method: 'PUT' }, 
-      ["Content-Type: application/json"], 
-      "fooobarr"
-    ).then((results) => {
+    httpstat(requestUrl, {
+      method: 'PUT',
+      headers: ['Content-Type: application/json'],
+      data: 'fooobarr',
+    }).then((results) => {
       server.close();
     });
   });
@@ -151,12 +151,10 @@ test('index.js: request with multipart content to http server', () => {
   server.on('listening', () => {
     const port = server.address().port;
     const requestUrl = `http://localhost:${port}/`;
-    httpstat(
-      requestUrl, 
-      { method: 'POST' }, 
-      null, null, 
-      ["foo=bar"]
-    ).then((results) => {
+    httpstat(requestUrl, {
+      method: 'POST',
+      formData: ["foo=bar"],
+    }).then((results) => {
       server.close();
     });
   });
@@ -185,12 +183,10 @@ test('index.js: request with multipart upload to http server', (_, fail) => {
   server.on('listening', () => {
     const port = server.address().port;
     const requestUrl = `http://localhost:${port}/`;
-    httpstat(
-      requestUrl, 
-      { method: 'POST' }, 
-      null, null, 
-      ["foo=@test/data/sample.json"]
-    ).then((results) => {
+    httpstat(requestUrl, {
+      method: 'POST',
+      formData:  ["foo=@test/data/sample.json"],
+    }).then((results) => {
       server.close();
     });
   });
@@ -198,12 +194,10 @@ test('index.js: request with multipart upload to http server', (_, fail) => {
 
 test('index.js: request with invalid file upload to http server', (_, fail) => {
   const requestUrl = `http://localhost/`;
-  httpstat(
-    requestUrl, 
-    { method: 'POST' }, 
-    null, null, 
-    ["foo=@test/data/does-not-exist.json"]
-  ).then(fail, mustCall((err) => {
+  httpstat(requestUrl, {
+      method: 'POST',
+      formData: ["foo=@test/data/does-not-exist.json"],
+    }).then(fail, mustCall((err) => {
     assert(err); 
     assert.equal(err.code, 'ENOENT');
     assert.equal(err.path, 'test/data/does-not-exist.json');


### PR DESCRIPTION
Update `main` function to accept an object literal as apposed to a series of parameters.

Also, the main function handles creating the `http` request options object;  The user then won't need to know anything about the request implementation to pass through `method` and `insecure`.

Should hopefully make httpstat more scalable - the main function's signature does not need to be updated if new parameters are required.

Updated README to include changes to API

**Note:** This would be a breaking change for existing users of httpstat