### PR TITLE
fix: Fix layout alignment, center strings

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -3,13 +3,13 @@ const colors = require('util').inspect.colors;
 
 const HTTPS_TEMPLATE = `` +
 		`  DNS Lookup   TCP Connection   SSL Handshake   Server Processing   Content Transfer` + "\n"+
-		`[ %s  |     %s  |        %s  |       %s  |         %s  ]` + "\n" +
-		`             |                |                   |                  |                    |` + "\n" +
-		`    namelookup:%s      |                   |                  |                    |` + "\n"+
-		`                        connect:%s         |                  |                    |` + "\n"+
-		`                                    pretransfer:%s            |                    |` + "\n"+
-		`                                                      starttransfer:%s             |` + "\n"+
-		`                                                                                 total:%s` + "\n";
+		`[  %s |    %s   |   %s   |     %s     |     %s    ]` + "\n" +
+		`             |                |               |                   |                  |` + "\n" +
+		`   namelookup:%s       |               |                   |                  |` + "\n"+
+		`                       connect:%s      |                   |                  |` + "\n"+
+		`                                   pretransfer:%s          |                  |` + "\n"+
+		`                                                     starttransfer:%s         |` + "\n"+
+		`                                                                                total:%s` + "\n";
 
 const HTTPS_TEMPLATE_JSON =
         `{"dns_lookup" : "%s" ,"tcp_connection" : "%s", "ssl_handshake" : "%s", ` +
@@ -17,13 +17,13 @@ const HTTPS_TEMPLATE_JSON =
         `"connect" : "%s", "pre_transfer": "%s", "start_transfer" : "%s", "total" : "%s"}`;
 
 const HTTP_TEMPLATE = `` +
-		`   DNS Lookup   TCP Connection   Server Processing   Content Transfer` + "\n" +
-		`[ %s  |     %s  |        %s  |       %s  ]` + "\n" +
+		`  DNS Lookup   TCP Connection   Server Processing   Content Transfer` + "\n" +
+		`[  %s |    %s   |     %s     |     %s    ]` + "\n" +
 		`             |                |                   |                  |` + "\n" +
-		`    namelookup:%s      |                   |                  |` + "\n" +
-		`                        connect:%s         |                  |` + "\n" +
-		`                                      starttransfer:%s        |` + "\n" +
-		`                                                                 total:%s` + "\n";
+		`   namelookup:%s       |                   |                  |` + "\n" +
+		`                       connect:%s          |                  |` + "\n" +
+		`                                     starttransfer:%s         |` + "\n" +
+		`                                                                total:%s` + "\n";
 
 const HTTP_TEMPLATE_JSON =
     `{"dns_lookup" : "%s" ,"tcp_connection" : "%s", ` +
@@ -34,8 +34,16 @@ function colorize(str, color) {
   return '\u001b[' + color[0] + 'm' + str + '\u001b[' + color[1] + 'm';
 }
 
+function center(str, width) {
+  if (str.length >= width) {
+    return str;
+  }
+  const spaces = width - str.length;
+  return str.padStart(str.length + spaces / 2, ' ').padEnd(width, ' ');
+}
+
 function fmta(duration) {
-  return colorize(sprintf("%7dms", duration), colors.cyan);
+  return colorize(center(duration + 'ms', 9), colors.cyan);
 };
 
 function fmtb(duration) {


### PR DESCRIPTION
* center-align the timings in the first row.
* The vertical bars are now also aligned right between the column headers.
* Aligned the `:` with the vertical bars for better esthetics.

HTTPS before
![image](https://user-images.githubusercontent.com/498419/139652432-0e5e8356-8651-4d4b-9118-e6024a1ee4b3.png)

HTTPS after
![image](https://user-images.githubusercontent.com/498419/139652489-4d968c70-bfca-475b-9d85-630758a78e3d.png)


HTTP before
![image](https://user-images.githubusercontent.com/498419/139652568-e80f3628-8177-4c9f-93c8-4e6d476663d5.png)

HTTP after
![image](https://user-images.githubusercontent.com/498419/139652599-2358f0cd-ac08-4b55-b0e9-173a13bea645.png)

